### PR TITLE
modif méthode new/create

### DIFF
--- a/app/controllers/pokemons_controller.rb
+++ b/app/controllers/pokemons_controller.rb
@@ -5,11 +5,11 @@ class PokemonsController < ApplicationController
   end
 
   def new
-    @pokemon = pokemon.new
+    @pokemon = Pokemon.new
   end
 
   def create
-    @pokemon = pokemon.new(pokemon_params)
+    @pokemon = Pokemon.new(pokemon_params)
     @pokemon.user = current_user
 
     if @pokemon.save


### PR DESCRIPTION
En allant voir l'affichage de mes seeds rails a affiché une erreur sur les méthodes new create  =>
manquait les majuscules pour : @pokemon = Pokemon.new pour les méthodes new et create
J'ai donc aussi mis à jour la branche add-model-pokemon pour qu'elle aient les dernieres modif (et donc les seed)

